### PR TITLE
feat: Windows (PowerShell) 対応を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,12 +22,19 @@
 
 ## 前提条件
 
+### macOS / Linux
 - **jq** - JSON解析に必要
+- **git** - ブランチ表示に使用（オプション）
+
+### Windows
+- **PowerShell 5.1+**（Windows 10/11 に標準搭載）
 - **git** - ブランチ表示に使用（オプション）
 
 ## インストール
 
-### クイックインストール
+### macOS / Linux
+
+#### クイックインストール
 
 ```bash
 git clone https://github.com/ueki-interpark/claude-code-statusline.git
@@ -40,7 +47,7 @@ cd claude-code-statusline
 2. `~/.claude/settings.json` に statusLine 設定を追加
 3. 既存の settings.json をバックアップ
 
-### 手動インストール
+#### 手動インストール
 
 1. `statusline.sh` を `~/.claude/` にコピー:
 
@@ -59,6 +66,44 @@ chmod +x ~/.claude/statusline.sh
   }
 }
 ```
+
+3. Claude Code を再起動してください。
+
+### Windows (PowerShell)
+
+#### クイックインストール
+
+```powershell
+git clone https://github.com/ueki-interpark/claude-code-statusline.git
+cd claude-code-statusline
+powershell -ExecutionPolicy Bypass -File install.ps1
+```
+
+インストールスクリプトは以下を行います:
+1. `statusline.ps1` を `~/.claude/` にコピー
+2. `~/.claude/settings.json` に PowerShell 用の statusLine 設定を追加
+3. 既存の settings.json をバックアップ
+
+#### 手動インストール
+
+1. `statusline.ps1` を `~/.claude/` にコピー:
+
+```powershell
+Copy-Item statusline.ps1 "$env:USERPROFILE\.claude\statusline.ps1"
+```
+
+2. `~/.claude/settings.json` に以下を追加:
+
+```json
+{
+  "statusLine": {
+    "type": "command",
+    "command": "powershell -NoProfile -ExecutionPolicy Bypass -File \"C:/Users/<ユーザー名>/.claude/statusline.ps1\""
+  }
+}
+```
+
+> `<ユーザー名>` は実際のユーザー名に置き換えてください。`install.ps1` を使うと自動で設定されます。
 
 3. Claude Code を再起動してください。
 

--- a/install.ps1
+++ b/install.ps1
@@ -1,0 +1,59 @@
+# claude-code-statusline installer (PowerShell)
+# Copies statusline.ps1 to ~/.claude/ and configures settings.json
+
+$ErrorActionPreference = "Stop"
+
+$ClaudeDir = Join-Path $env:USERPROFILE ".claude"
+$SettingsFile = Join-Path $ClaudeDir "settings.json"
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SourceScript = Join-Path $ScriptDir "statusline.ps1"
+$DestScript = Join-Path $ClaudeDir "statusline.ps1"
+
+# Check source file exists
+if (-not (Test-Path $SourceScript)) {
+    Write-Error "Error: statusline.ps1 not found at $SourceScript"
+    exit 1
+}
+
+# Ensure ~/.claude directory exists
+if (-not (Test-Path $ClaudeDir)) {
+    New-Item -ItemType Directory -Path $ClaudeDir -Force | Out-Null
+}
+
+# Copy statusline.ps1
+Copy-Item -Path $SourceScript -Destination $DestScript -Force
+Write-Host "Copied statusline.ps1 to $DestScript"
+
+# statusLine command
+$StatusLineCommand = 'powershell -NoProfile -ExecutionPolicy Bypass -File "' + (Join-Path $env:USERPROFILE '.claude\statusline.ps1') + '"'
+$StatusLineConfig = @{
+    type    = "command"
+    command = $StatusLineCommand
+}
+
+# Update settings.json
+if (Test-Path $SettingsFile) {
+    # Backup existing settings
+    $BackupFile = "$SettingsFile.bak"
+    Copy-Item -Path $SettingsFile -Destination $BackupFile -Force
+    Write-Host "Backed up settings.json to $BackupFile"
+
+    # Read and update settings
+    $Settings = Get-Content -Path $SettingsFile -Raw | ConvertFrom-Json
+    # Remove existing statusLine property if present, then add new one
+    if ($Settings.PSObject.Properties['statusLine']) {
+        $Settings.PSObject.Properties.Remove('statusLine')
+    }
+    $Settings | Add-Member -NotePropertyName 'statusLine' -NotePropertyValue $StatusLineConfig
+    $Settings | ConvertTo-Json -Depth 10 | Set-Content -Path $SettingsFile -Encoding UTF8
+} else {
+    # Create new settings.json
+    $Settings = @{
+        statusLine = $StatusLineConfig
+    }
+    $Settings | ConvertTo-Json -Depth 10 | Set-Content -Path $SettingsFile -Encoding UTF8
+}
+
+Write-Host "Updated $SettingsFile with statusLine configuration"
+Write-Host ""
+Write-Host "Installation complete! Restart Claude Code to see the status line."

--- a/statusline.ps1
+++ b/statusline.ps1
@@ -1,0 +1,87 @@
+# claude-code-statusline - Custom status line for Claude Code CLI (PowerShell)
+# https://github.com/ueki-interpark/claude-code-statusline
+
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
+$input = $Input | Out-String
+$data = $input | ConvertFrom-Json
+
+$Model = if ($data.model.display_name) { $data.model.display_name } else { "unknown" }
+$Cost = if ($data.cost.total_cost_usd) { $data.cost.total_cost_usd } else { 0 }
+$UsedPct = if ($data.context_window.used_percentage) { $data.context_window.used_percentage } else { 0 }
+$Cwd = if ($data.cwd) { $data.cwd } else { "" }
+
+$CostFmt = '$' + '{0:F4}' -f [double]$Cost
+$UsedInt = [math]::Round([double]$UsedPct)
+
+# Emoji definitions (use codepoints to avoid encoding issues)
+$ICON_SHUFFLE = [char]::ConvertFromUtf32(0x1F500)  # 🔀
+$ICON_FOLDER  = [char]::ConvertFromUtf32(0x1F4C2)  # 📂
+$ICON_BRANCH  = [char]::ConvertFromUtf32(0x1F33F)  # 🌿
+$ICON_ROBOT   = [char]::ConvertFromUtf32(0x1F916)  # 🤖
+$ICON_MONEY   = [char]::ConvertFromUtf32(0x1F4B0)  # 💰
+$ICON_BRAIN   = [char]::ConvertFromUtf32(0x1F9E0)  # 🧠
+
+# Color definitions (ANSI escape sequences)
+$ESC = [char]27
+$CYAN = "$ESC[36m"
+$GREEN = "$ESC[32m"
+$YELLOW = "$ESC[33m"
+$RED = "$ESC[31m"
+$MAGENTA = "$ESC[35m"
+$DIM = "$ESC[2m"
+$RESET = "$ESC[0m"
+
+# Context usage color coding
+if ($UsedInt -ge 80) {
+    $CtxColor = $RED
+} elseif ($UsedInt -ge 50) {
+    $CtxColor = $YELLOW
+} else {
+    $CtxColor = $GREEN
+}
+
+# Context usage progress bar
+$Filled = [math]::Floor($UsedInt / 5)
+$Empty = 20 - $Filled
+$Bar = ('#' * $Filled) + ('-' * $Empty)
+
+# Shorten path (replace $HOME with ~)
+# Normalize to forward slashes before comparison
+$HomeDir = ($env:USERPROFILE) -replace '\\', '/'
+$CwdNorm = $Cwd -replace '\\', '/'
+if ($CwdNorm -and $HomeDir -and $CwdNorm.StartsWith($HomeDir)) {
+    $Dir = '~' + $CwdNorm.Substring($HomeDir.Length)
+} else {
+    $Dir = $CwdNorm
+}
+
+$Parts = $Dir -split '/'
+if ($Parts.Count -gt 3) {
+    $ShortDir = $Parts[0] + '/.../' + ($Parts[-2..-1] -join '/')
+} else {
+    $ShortDir = $Dir
+}
+
+# Get current Git branch
+$Branch = ""
+if ($Cwd -and (Get-Command git -ErrorAction SilentlyContinue)) {
+    try {
+        $Branch = git -C $Cwd branch --show-current 2>$null
+    } catch {
+        $Branch = ""
+    }
+}
+
+# Line 1: Location and branch (with icons)
+if ($Branch) {
+    $Line1 = "${ICON_SHUFFLE} ${CYAN}${ShortDir}${RESET} ${DIM}on${RESET} ${ICON_BRANCH} ${MAGENTA}${Branch}${RESET}"
+} else {
+    $Line1 = "${ICON_FOLDER} ${CYAN}${ShortDir}${RESET}"
+}
+
+# Line 2: Model, cost, and context usage
+$Line2 = "${ICON_ROBOT} ${DIM}${Model}${RESET} | ${ICON_MONEY} ${GREEN}${CostFmt}${RESET} | ${ICON_BRAIN} ${CtxColor}[${Bar}] ${UsedInt}%${RESET}"
+
+Write-Host $Line1
+Write-Host $Line2


### PR DESCRIPTION
## Summary
- `statusline.ps1`: PowerShell版ステータスライン（ConvertFrom-Json使用、jq不要）
- `install.ps1`: Windows用インストーラー（settings.json自動設定・バックアップ）
- `README.md`: Windows向けインストール手順を追加（前提条件の分割含む）

Closes #2